### PR TITLE
[Backend] Add try-except for OpenAI API and Logging (#2)

### DIFF
--- a/core/planner.py
+++ b/core/planner.py
@@ -1,10 +1,15 @@
 import os
+import logging
 from dotenv import load_dotenv
-from openai import OpenAI
+from openai import OpenAI, OpenAIError, AuthenticationError, RateLimitError
 from api.schema import MamiPlan
 
 # Load environment variables (API keys, configurations) from .env file
 load_dotenv()
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
 
 # Initialize the OpenAI client
 # The API key is securely retrieved from the environment
@@ -15,31 +20,47 @@ def generate_mami_plan(user_input: str, world_state: str, history: list = []) ->
     Translates a natural language instruction into a structured 
     robotic execution plan based on the Mami schema.
     """
+    logger.info("Generating Mami plan for input: %s", user_input)
     
-    # Call the reasoning model (GPT-4o) with structured output enforcement
-    response = client.beta.chat.completions.parse(
-        model="gpt-4o",
-        messages=[
-            {
-                "role": "system", 
-                "content": (
-                    "You are 'Mami', a wise robotic agent. "
-                    "Analyze the ENVIRONMENT and the USER REQUEST "
-                    "to define a strategy and justify every action."
-                )
-            },
-            *history,  # <--- Questo inserisce i messaggi passati
-            {
-                "role": "user", 
-                "content": (
-                    f"ENVIRONMENT: {world_state}\n"
-                    f"USER REQUEST: {user_input}"
-                )
-            },
-        ],
-        # Enforce the schema defined in api/schema.py
-        response_format=MamiPlan,
-    )
-    
-    # Returns the validated object, ready for the robot's hardware abstraction layer
-    return response.choices[0].message.parsed
+    try:
+        # Call the reasoning model (GPT-4o) with structured output enforcement
+        response = client.beta.chat.completions.parse(
+            model="gpt-4o",
+            messages=[
+                {
+                    "role": "system", 
+                    "content": (
+                        "You are 'Mami', a wise robotic agent. "
+                        "Analyze the ENVIRONMENT and the USER REQUEST "
+                        "to define a strategy and justify every action."
+                    )
+                },
+                *history,  # <--- Questo inserisce i messaggi passati
+                {
+                    "role": "user", 
+                    "content": (
+                        f"ENVIRONMENT: {world_state}\n"
+                        f"USER REQUEST: {user_input}"
+                    )
+                },
+            ],
+            # Enforce the schema defined in api/schema.py
+            response_format=MamiPlan,
+        )
+        
+        plan = response.choices[0].message.parsed
+        logger.info("Successfully generated Mami plan")
+        return plan
+
+    except AuthenticationError:
+        logger.error("OpenAI Authentication Error. Please check your API key.")
+        raise
+    except RateLimitError:
+        logger.error("OpenAI Rate Limit Error. Too many requests.")
+        raise
+    except OpenAIError as e:
+        logger.error(f"OpenAI API Error: {e}")
+        raise
+    except Exception as e:
+        logger.error(f"Unexpected error in generate_mami_plan: {e}")
+        raise


### PR DESCRIPTION
Implemented robust error handling for OpenAI API calls in `core/planner.py`. 

Key changes:
- Added `logging` for tracking reasoning flow.
- Wrapped `client.beta.chat.completions.parse` in a `try-except` block.
- Handled `AuthenticationError`, `RateLimitError`, and general `OpenAIError` with informative logs. 

Fixes #2